### PR TITLE
Update OSD 2D map reference line settings docs

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4654,7 +4654,7 @@ Number of decimals for the battery voltages displayed in the OSD [1-2].
 
 ### osd_map2d_hmargin
 
-Horizontal margin (both left and right) for OSD 2D map borders. The map items won't be drawn into any of the columns within this number.
+OSD 2D Map horizontal margin (on left and right, columns the map won't use for drawing)
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -4664,7 +4664,7 @@ Horizontal margin (both left and right) for OSD 2D map borders. The map items wo
 
 ### osd_map2d_ref_line_heading
 
-Draws a dashed line on the center of the map display, if using "up is north" setting. The line is aligned at the heading set by this parameter. This should be set to the same heading as an easily recognizable feature nearby the place you are flying, for example the same heading as the runway (if flying from a club), street or a nearby fence. So now you are able to compare the craft's position on the OSD map with this reference, making it easier to orientate yourself, better align directional antennas and so on. Default setting of -1 disables this line.
+OSD 2D Map reference line heading (0 is north, 90 east, 180 south and so on, -1 disabled). Requires using "up is north" map setting. The dashed line will be aligned to the heading set by this parameter. So should be set to the same heading as an easily recognizable and static feature nearby the place you are flying, for example a runway, a street, a fence, etc. Then you are able to compare the craft's position on the OSD map with this reference, making it easier to orientate yourself, align directional antennas and so on.
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -4674,7 +4674,7 @@ Draws a dashed line on the center of the map display, if using "up is north" set
 
 ### osd_map2d_vmargin
 
-Vertical margin (both top and bottom) for OSD 2D map borders. The map items won't be drawn into any of the lines within this number.
+OSD 2D Map vertical margin (on top and bottom, lines the map won't use for drawing)
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3673,21 +3673,21 @@ groups:
         max: 5000
       
       - name: osd_map2d_vmargin
-        description: OSD 2D Map vertical lines margin (on top and bottom, spaces where nothing will be drawn)
+        description: OSD 2D Map vertical margin (on top and bottom, lines the map won't use for drawing)
         field: map2d_vmargin
         default_value: 3
         min: 0
         max: 10
       
       - name: osd_map2d_hmargin
-        description: OSD 2D Map horizontal lines margin (on left and right)
+        description: OSD 2D Map horizontal margin (on left and right, columns the map won't use for drawing)
         field: map2d_hmargin
         default_value: 5
         min: 0
         max: 15
       
       - name: osd_map2d_ref_line_heading
-        description: OSD 2D Map reference line heading (0 is north, 90 east, 180 south and so on, -1 disabled)
+        description: OSD 2D Map reference line heading (0 is north, 90 east, 180 south and so on, -1 disabled). Requires using "up is north" map setting. The dashed line will be aligned to the heading set by this parameter. So should be set to the same heading as an easily recognizable and static feature nearby the place you are flying, for example a runway, a street, a fence, etc. Then you are able to compare the craft's position on the OSD map with this reference, making it easier to orientate yourself, align directional antennas and so on.
         field: map2d_ref_line_heading
         default_value: -1
         min: -1

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1286,7 +1286,7 @@ int osdGetHeadingAngle(int angle)
 static void osdDrawMapReferenceLine(uint8_t midX, uint8_t midY)
 {   
     float heading = osdConfig()->map2d_ref_line_heading;
-    float rollAngle = DEGREES_TO_RADIANS(90.f - (heading > 180.0 ? heading - 180.f: heading));
+    float rollAngle = DEGREES_TO_RADIANS(90.f - (heading > 180.f ? heading - 180.f: heading));
     const float ky = sin_approx(rollAngle);
     const float kx = cos_approx(rollAngle);
     const float ratio = osdDisplayIsPAL() ? 12.0f/15.0f : 12.0f/18.46f;


### PR DESCRIPTION
This was added in previous commits [14e65ec9](https://github.com/rmaia3d/inavR/commit/14e65ec97140fe6b553138bd38185d8fdb9999c4) and [21c2bd3](https://github.com/rmaia3d/inavR/commit/21c2bd3fd9f8d396eb7f55cee9b53aaede3f1d67), and since it's not available on the official Inav release, here's some documentation on the feature.

The "OSD 2D map reference line" draws a dashed line on the center of the map display, if using "up is north" setting. The line is aligned at the heading set by a configurable parameter. The idea is to set this heading to the same heading as an easily recognizable and static feature nearby the place you are flying, for example the runway (if flying from a club), a nearby street or fence. So now you are able to compare the craft's position on the OSD map with this reference, making it easier to orientate yourself, better align directional antennas and so on. If set to -1 (the default setting), this line is disabled.

These new parameters are only configurable via the CLI. They would require a fork and custom build of Inav configurator to be added to the UI as well, but since JScript is not my area of expertise, I won't be touching that for now.

A screenshot of the line enabled and configured:

![image](https://github.com/rmaia3d/inavR/assets/9812730/1eacb0d1-7019-4788-88d4-0b702946d71e)

The light blue circle is the arrow which represents the craft's current position and heading (where the arrow is pointed to). The magenta ellipse marks the AHI line (artificial horizon, which works just fine together with the features from this PR). The red arrow points the 2D Map reference line (this new feature), configured to be aligned with the main runway (pointed to by the purple arrow).