### PR TITLE
Fix inav_use_gps_no_baro default

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1844,11 +1844,11 @@ Allows to chose when the home position is reset. Can help prevent resetting home
 
 ### inav_use_gps_no_baro
 
-Defines if INAV should use only use GPS data for altitude estimation when barometer is not available. If set to ON, INAV will allow GPS assisted modes and RTH even when there is no barometer installed.
+Defines if INAV should use only GPS data for altitude estimation and not barometer. If set to ON, INAV will allow GPS assisted modes and RTH even when there is no barometer installed.
 
 | Default | Min | Max |
 | --- | --- | --- |
-| ON | OFF | ON |
+| OFF | OFF | ON |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2288,10 +2288,10 @@ groups:
         field: use_gps_velned
         type: bool
       - name: inav_use_gps_no_baro
-        description: "Defines if INAV should use only use GPS data for altitude estimation when barometer is not available. If set to ON, INAV will allow GPS assisted modes and RTH even when there is no barometer installed."
+        description: "Defines if INAV should use only GPS data for altitude estimation and not barometer. If set to ON, INAV will allow GPS assisted modes and RTH even when there is no barometer installed."
         field: use_gps_no_baro
         type: bool
-        default_value: ON
+        default_value: OFF
       - name: inav_allow_dead_reckoning
         description: "Defines if INAV will dead-reckon over short GPS outages. May also be useful for indoors OPFLOW navigation"
         default_value: OFF


### PR DESCRIPTION
A bug related to this setting has been found on Inav 7.1.1, which this branch is based on. 

<img width="896" alt="image" src="https://github.com/rmaia3d/inavR/assets/9812730/08faaaab-138e-451d-87e5-594352641f7d">

This PR ports the fix to here.

More info on the bug can be found on the official Inav repo, under issue `#10040`.