### PR TITLE
Improvements to BFCOMPAT OSD items

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2058,9 +2058,18 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
 
     case OSD_TRIP_DIST:
-        buff[0] = SYM_TOTAL;
-        osdFormatDistanceSymbol(buff + 1, getTotalTravelDistance(), 0);
+    {
+        uint8_t buff_offset = 1U;
+        if (bfcompat) {
+            buff[0] = 'T';
+            buff[1] = 'D';
+            buff_offset = 2U;
+        } else {
+            buff[0] = SYM_TOTAL;
+        }
+        osdFormatDistanceSymbol(buff + buff_offset, getTotalTravelDistance(), 0);
         break;
+    }
 
     case OSD_ODOMETER:
         {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3131,15 +3131,19 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_POWER:
         {
-            uint8_t digits = 3U;                
-            #ifndef DISABLE_MSP_BF_COMPAT // IF BFCOMPAT is not supported, there's no need to check for it and change the values
-                if (isBfCompatibleVideoSystem(osdConfig())) {
-                    digits = 4U;
-                }            
-            #endif
+            uint8_t digits = 3U;
+            if (bfcompat) {
+                digits = 4U;
+            }                
             bool kiloWatt = osdFormatCentiNumber(buff, getPower(), 1000, 2, 2, digits, false);
-            buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
-            buff[digits + 1] = '\0';
+            if(bfcompat) {
+                buff[digits] = kiloWatt ? 'K' : SYM_WATT;
+                buff[digits + 1U] = kiloWatt ? SYM_WATT : SYM_BLANK;
+                buff[digits + 2U] = '\0';
+            } else {
+                buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
+                buff[digits + 1] = '\0';
+            }
 
             uint8_t current_alarm = osdConfig()->current_alarm;
             if ((current_alarm > 0) && ((getAmperage() / 100.0f) > current_alarm)) {
@@ -4691,14 +4695,22 @@ static void osdShowStats(bool isSinglePageStatsCompatible, uint8_t page)
             displayWrite(osdDisplayPort, statNameX, top, "MAX POWER        :");
             uint8_t digits = 3U;
             bool kiloWatt = false;
+            bool bfcompat = false;
             #ifndef DISABLE_MSP_BF_COMPAT // IF BFCOMPAT is not supported, there's no need to check for it and change the values
                 if (isBfCompatibleVideoSystem(osdConfig())) {
                     digits = 4U;
+                    bfcompat = true;
                 }            
             #endif
             kiloWatt = osdFormatCentiNumber(buff, stats.max_power, 1000, 2, 2, digits, false);            
-            buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
-            buff[digits + 1U] = '\0';
+            if (bfcompat) {
+                buff[digits] = kiloWatt ? 'K' : SYM_WATT;
+                buff[digits + 1U] = kiloWatt ? SYM_WATT : SYM_BLANK;
+                buff[digits + 2U] = '\0';
+            } else {
+                buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
+                buff[digits + 1U] = '\0';
+            }
             displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
             displayWrite(osdDisplayPort, statNameX, top, "USED CAPACITY    :");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3378,9 +3378,18 @@ static bool osdDrawSingleElement(uint8_t item)
             uint16_t angle;
             horizontalWindSpeed = getEstimatedHorizontalWindSpeed(&angle);
             int16_t windDirection = osdGetHeadingAngle( CENTIDEGREES_TO_DEGREES((int)angle) - DECIDEGREES_TO_DEGREES(attitude.values.yaw) + 22);
-            buff[0] = SYM_WIND_HORIZONTAL;
-            buff[1] = SYM_DIRECTION + (windDirection*2 / 90);
-            osdFormatWindSpeedStr(buff + 2, horizontalWindSpeed, valid);
+
+            uint8_t buff_offset = 2U;
+            if(bfcompat) {
+                buff[0] = 'H';
+                buff[1] = 'W';
+                buff_offset = 3;
+            } else {
+                buff[0] = SYM_WIND_HORIZONTAL;
+            }
+
+            buff[buff_offset - 1U] = SYM_DIRECTION + (windDirection*2 / 90);
+            osdFormatWindSpeedStr(buff + buff_offset, horizontalWindSpeed, valid);
             break;
         }
 #else
@@ -3390,18 +3399,31 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_WIND_SPEED_VERTICAL:
 #ifdef USE_WIND_ESTIMATOR
         {
-            buff[0] = SYM_WIND_VERTICAL;
-            buff[1] = SYM_BLANK;
+            uint8_t buff_offset = 2U;
+            uint8_t arrow_up = SYM_AH_DIRECTION_UP;
+            uint8_t arrow_down = SYM_AH_DIRECTION_DOWN;
+
+            if(bfcompat) {
+                buff[0] = 'V';
+                buff[1] = 'W';
+                buff_offset = 3U;
+                arrow_up = SYM_DIRECTION;   // Translated by getBfCharacter() to an up pointing arrow
+                arrow_down = SYM_DIRECTION + 4U;    // Translated by getBfCharacter() to a down pointing arrow
+            } else {
+                buff[0] = SYM_WIND_VERTICAL;
+            }
+            buff[buff_offset - 1U] = SYM_BLANK;
+
             bool valid = isEstimatedWindSpeedValid();
             float verticalWindSpeed;
             verticalWindSpeed = -getEstimatedWindSpeed(Z);  //from NED to NEU
             if (verticalWindSpeed < 0) {
-                buff[1] = SYM_AH_DIRECTION_DOWN;
+                buff[buff_offset - 1U] = arrow_down;
                 verticalWindSpeed = -verticalWindSpeed;
             } else {
-                buff[1] = SYM_AH_DIRECTION_UP;
+                buff[buff_offset - 1U] = arrow_up;
             }
-            osdFormatWindSpeedStr(buff + 2, verticalWindSpeed, valid);
+            osdFormatWindSpeedStr(buff + buff_offset, verticalWindSpeed, valid);
             break;
         }
 #else

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2613,21 +2613,63 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
 
     case OSD_ATTITUDE_ROLL:
-        buff[0] = SYM_ROLL_LEVEL;
-        if (ABS(attitude.values.roll) >= 1)
-            buff[0] += (attitude.values.roll < 0 ? -1 : 1);
-        osdFormatCentiNumber(buff + 1, DECIDEGREES_TO_CENTIDEGREES(ABS(attitude.values.roll)), 0, 1, 0, 3, false);
-        break;
+        {
+            uint8_t buff_offset = 1U;
+            buff[0] = SYM_ROLL_LEVEL;
+            if(bfcompat) {
+                if (ABS(attitude.values.roll) >= 1) {
+                    if (attitude.values.roll < 0) {
+                        // Left roll
+                        buff[1] = SYM_DIRECTION + 6U;   // This will be remapped in getBfCharacter() to a left pointing arrow
+                    } else {
+                        // Right roll
+                        buff[1] = SYM_DIRECTION + 2U;   // This will be remapped in getBfCharacter() to a right pointing arrow
+                    }
+                } else {
+                    buff[1] = SYM_BLANK;    // Roll angle too small
+                }
+                buff_offset = 2U;
+            } else {
+                if (ABS(attitude.values.roll) >= 1)
+                    buff[0] += (attitude.values.roll < 0 ? -1 : 1);
+            }
+            osdFormatCentiNumber(buff + buff_offset, DECIDEGREES_TO_CENTIDEGREES(ABS(attitude.values.roll)), 0, 1, 0, 3, false);
+            break;
+        }
 
     case OSD_ATTITUDE_PITCH:
-        if (ABS(attitude.values.pitch) < 1)
-            buff[0] = 'P';
-        else if (attitude.values.pitch > 0)
-            buff[0] = SYM_PITCH_DOWN;
-        else if (attitude.values.pitch < 0)
-            buff[0] = SYM_PITCH_UP;
-        osdFormatCentiNumber(buff + 1, DECIDEGREES_TO_CENTIDEGREES(ABS(attitude.values.pitch)), 0, 1, 0, 3, false);
-        break;
+        {
+            uint8_t buff_offset = 1U;
+            if (bfcompat) {
+                buff[0] = SYM_PITCH_UP;    // 0x15 is the DJI's font pitch symbol
+                if (ABS(attitude.values.pitch) < 1) {
+                    // Angle too small
+                    buff[1] = SYM_BLANK;
+                } else {
+                    if (attitude.values.pitch > 0) {
+                        // Nose down pitch
+                        buff[1] = SYM_DIRECTION + 4U;   // This will be remapped in getBfCharacter() to a down pointing arrow
+                    }
+                    else if (attitude.values.pitch < 0) {
+                        // Nose up pitch
+                        buff[1] = SYM_DIRECTION;    // This will be remapped in getBfCharacter() to an up pointing arrow
+                    } else {
+                        // Some error occurred, ignore
+                        buff[1] = SYM_BLANK;
+                    }
+                }
+                buff_offset = 2U;
+            } else {
+                if (ABS(attitude.values.pitch) < 1)
+                    buff[0] = 'P';
+                else if (attitude.values.pitch > 0)
+                    buff[0] = SYM_PITCH_DOWN;
+                else if (attitude.values.pitch < 0)
+                    buff[0] = SYM_PITCH_UP;
+            }
+            osdFormatCentiNumber(buff + buff_offset, DECIDEGREES_TO_CENTIDEGREES(ABS(attitude.values.pitch)), 0, 1, 0, 3, false);
+            break;
+        }
 
     case OSD_ARTIFICIAL_HORIZON:
         {


### PR DESCRIPTION
Adds some improvements to the BFCOMPAT OSD items. Some items have had the label extended from the single character limitation, so more meaningful letter abbreviations can be used (For example, Airspeed from `A` to `AS`, Horizontal windspeed from `W` to `HW`, Vertical windspeed is `VW`, Total flown distance is  `TD` and so on). 

Pitch and roll items now also feature arrows pointing to which direction the roll or pitch is (up or down and left or right).

Temperature items have letter labels to differentiate between them (C for IMU, B for baro and E for ESC).

With the improvements here, it's possible to have the OSD look like this:

![Inav_O3_OSD_no_coords3](https://github.com/rmaia3d/inavR/assets/9812730/457516a1-8c69-4b16-ab3b-dfae3cb66d3f)
